### PR TITLE
Updating class name to match current namespace

### DIFF
--- a/woographql-subscriptions.php
+++ b/woographql-subscriptions.php
@@ -65,7 +65,7 @@ function woographql_subscriptions_dependencies_not_ready() {
         $deps[] = 'WooCommerce Subscriptions';
     }
 
-    if ( ! class_exists( '\WP_GraphQL_WooCommerce' ) ) {
+    if ( ! class_exists( '\WPGraphQL\WooCommerce' ) ) {
         $deps[] = 'WooGraphQL';
     }
 


### PR DESCRIPTION
Doesn't work with the most recent version of WooGraphql as the Class name has changed. Updated this in the dependency array and all works correctly now